### PR TITLE
增加 kConversationId 的说明

### DIFF
--- a/iOS/LeanMessageDemo/LeanMessageDemo/BaseChatViewController.m
+++ b/iOS/LeanMessageDemo/LeanMessageDemo/BaseChatViewController.m
@@ -14,9 +14,6 @@
 #import "MessageTableViewCell.h"
 
 
-#define kConversationId @"55cd829e60b2b52cda834469"
-
-
 // 自定义属性来区分单聊和群聊
 typedef enum : NSUInteger {
     ConversationTypeOneToOne = 0,

--- a/iOS/LeanMessageDemo/LeanMessageDemo/ChatRoomViewController.m
+++ b/iOS/LeanMessageDemo/LeanMessageDemo/ChatRoomViewController.m
@@ -22,7 +22,7 @@
     // 新建一个针对 AVIMConversation 的查询，根据 Id 查询出对应的 AVIMConversation 实例
     AVIMConversationQuery *query = [self.imClient conversationQuery];
     [query getConversationById:kConversationId callback:^(AVIMConversation *conversation, NSError *error) {
-        // 注意：如果查询出来的 conversation 为 nil，请在控制台 _Conversation 表创建一条 tr 字段为 true 的数据，然后将这条数据的 objectId 替换掉上方的 kConversationId
+        #warning : 如果查询出来的 conversation 为 nil，请在控制台 _Conversation 表创建一条 tr 字段为 true 的数据，然后将这条数据的 objectId 替换掉上方的 kConversationId
         // 将当前所在的对话实例设置为查询出来的 conversation
         self.currentConversation=conversation;
         // 注意：如果不主动调用 joinWithCallback 方法，则不会收到聊天室的消息通知

--- a/iOS/LeanMessageDemo/LeanMessageDemo/ChatRoomViewController.m
+++ b/iOS/LeanMessageDemo/LeanMessageDemo/ChatRoomViewController.m
@@ -27,15 +27,17 @@
         self.currentConversation=conversation;
         // 注意：如果不主动调用 joinWithCallback 方法，则不会收到聊天室的消息通知
         [self.currentConversation joinWithCallback:^(BOOL succeeded, NSError *error) {
-            NSLog(@"成功加入聊天室，开始接收消息。");
-        }];
-        // 初始化消息发送面板（消息输入框，发送按钮）
-        [self initMessageToolBar];
-        // 查询最近的 10 条聊天记录
-        [conversation queryMessagesWithLimit:kPageSize callback:^(NSArray *objects, NSError *error) {
-            // 刷新 Tabel 控件，为其添加数据源
-            [self.messages addObjectsFromArray:objects];
-            [self.messageTableView reloadData];
+            if (succeeded) {
+                NSLog(@"成功加入聊天室，开始接收消息。");
+                // 初始化消息发送面板（消息输入框，发送按钮）
+                [self initMessageToolBar];
+                // 查询最近的 10 条聊天记录
+                [conversation queryMessagesWithLimit:kPageSize callback:^(NSArray *objects, NSError *error) {
+                    // 刷新 Tabel 控件，为其添加数据源
+                    [self.messages addObjectsFromArray:objects];
+                    [self.messageTableView reloadData];
+                }];
+            }
         }];
     }];
 }

--- a/iOS/LeanMessageDemo/LeanMessageDemo/ChatRoomViewController.m
+++ b/iOS/LeanMessageDemo/LeanMessageDemo/ChatRoomViewController.m
@@ -22,6 +22,7 @@
     // 新建一个针对 AVIMConversation 的查询，根据 Id 查询出对应的 AVIMConversation 实例
     AVIMConversationQuery *query = [self.imClient conversationQuery];
     [query getConversationById:kConversationId callback:^(AVIMConversation *conversation, NSError *error) {
+        // 注意：如果查询出来的 conversation 为 nil，请在控制台 _Conversation 表创建一条 tr 字段为 true 的数据，然后将这条数据的 objectId 替换掉上方的 kConversationId
         // 将当前所在的对话实例设置为查询出来的 conversation
         self.currentConversation=conversation;
         // 注意：如果不主动调用 joinWithCallback 方法，则不会收到聊天室的消息通知


### PR DESCRIPTION
问题来源：
https://forum.leancloud.cn/t/getconversationbyid-what-the-fuck-is-id/5252
https://www.zhihu.com/question/39326344

问题说明：
用户不清楚聊天室代码中的kConversationId是什么怎么回事。

修改说明：
1、@sunng87 给出经验，绝大部分开放聊天室都是先在服务器端创建，然后在客户端搜索加入，少有在客户端直接建立开放聊天室的场景，因此增加了一段注释对 kConversationId 进行了说明。
2、删除了 BaseChatViewController 中的 kConversationId，因为逻辑中没有用到它，以免对用户造成疑惑。
3、明确了操作的逻辑顺序：将初始化消息面板的代码放入到 joinWithCallback 的回调中。